### PR TITLE
Expand pytest yaml sample

### DIFF
--- a/scripts/qesap/test/conftest.py
+++ b/scripts/qesap/test/conftest.py
@@ -14,6 +14,12 @@ def config_yaml_sample():
     config = """---
 terraform:
   provider: {}
+  variables:
+    az_region: "westeurope"
+    hana_ips: ["10.0.0.2", "10.0.0.3"]
+    hana_data_disks_configuration:
+      disk_type: "hdd,hdd,hdd"
+      disks_size: "64,64,64"
 ansible:
     hana_urls: onlyone"""
     def _callback(provider=None):


### PR DESCRIPTION
Extending yaml sample fixture for terraform. 
Includes exactly one string, list and dict based variable.

VR:
```
form linux -- Python 3.10.4, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: /var/home/lpalovsky/GIT/qe-sap-deployment/scripts/qesap
collected 39 items                                                                                                                               

test/unit/test_qesap_ansible.py .                                                                                                          [  2%]
test/unit/test_qesap_cli.py .............                                                                                                  [ 35%]
test/unit/test_qesap_configure.py .............                                                                                            [ 69%]
test/unit/test_qesap_deploy.py .                                                                                                           [ 71%]
test/unit/test_qesap_destroy.py .                                                                                                          [ 74%]
test/unit/test_qesap_terraform.py .....                                                                                                    [ 87%]
test/unit/test_subprocess_run.py .....                                                                                                     [100%]

=============================================================== 39 passed in 0.17s ===============================================================
```
